### PR TITLE
Rename IVestingNFT to IERC5725

### DIFF
--- a/EIPS/eip-5725.md
+++ b/EIPS/eip-5725.md
@@ -44,7 +44,7 @@ These curves could represent:
 6. Enable standardized fundraising implementations and general fundraising that sell vesting tokens (eg. SAFTs) in a more transparent manner.
 7. Allows tools, front-end apps, aggregators, etc. to show a more holistic view of the vesting tokens and the properties available to users.
     - Currently, every project needs to write their own visualization of the vesting schedule of their vesting assets. If this is standardized, third-party tools could be developed aggregate all vesting NFTs from all projects for the user, display their schedules and allow the user to take aggregated vesting actions.
-    - Such tooling can easily discover compliance through the [EIP-165](./eip-165.md) supportsInterface(IVestingNFT) check.
+    - Such tooling can easily discover compliance through the [EIP-165](./eip-165.md) supportsInterface(IERC5725) check.
 8. Makes it easier for a single wrapping implementation to be used across all vesting standards that defines multiple recipients, periodic renting of vesting tokens etc.
 
 
@@ -63,7 +63,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
  * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
  *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.
  */
-interface IVestingNFT is IERC721 {
+interface IERC5725 is IERC721 {
     event PayoutClaimed(uint256 indexed tokenId, address indexed recipient, uint256 _claimAmount);
 
     /**

--- a/assets/eip-5725/README.md
+++ b/assets/eip-5725/README.md
@@ -2,7 +2,7 @@
 This repository serves as a reference implementation for **EIP-5725 Transferrable Vesting NFT Standard**. A Non-Fungible Token (NFT) standard used to vest tokens (ERC-20 or otherwise) over a vesting release curve.
 
 ## Contents
-- [EIP-5725 Specification](./contracts/IVestingNFT.sol): Interface and definitions for the EIP-5725 specification.
-- [ERC-5725 Implementation (abstract)](./contracts/BaseVestingNFT.sol): ERC-5725 contract which can be extended to implement the specification. 
+- [EIP-5725 Specification](./contracts/IERC5725.sol): Interface and definitions for the EIP-5725 specification.
+- [ERC-5725 Implementation (abstract)](./contracts/ERC5725.sol): ERC-5725 contract which can be extended to implement the specification. 
 - [VestingNFT Implementation](./contracts/reference/LinearVestingNFT.sol): Full ERC-5725 implementation using cliff vesting curve.
 - [LinearVestingNFT Implementation](./contracts/reference/VestingNFT.sol): Full ERC-5725 implementation using linear vesting curve.

--- a/assets/eip-5725/contracts/ERC5725.sol
+++ b/assets/eip-5725/contracts/ERC5725.sol
@@ -6,9 +6,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
-import "./IVestingNFT.sol";
+import "./IERC5725.sol";
 
-abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
+abstract contract ERC5725 is IERC5725, ERC721 {
     using SafeERC20 for IERC20;
 
     /// @dev mapping for claimed payouts
@@ -25,9 +25,9 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
-    function claim(uint256 tokenId) external override(IVestingNFT) validToken(tokenId) returns (uint256 amountClaimed) {
+    function claim(uint256 tokenId) external override(IERC5725) validToken(tokenId) returns (uint256 amountClaimed) {
         require(ownerOf(tokenId) == msg.sender, "Not owner of NFT");
         amountClaimed = claimablePayout(tokenId);
         require(amountClaimed > 0, "VestingNFT: No pending payout");
@@ -39,29 +39,29 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
-    function vestedPayout(uint256 tokenId) public view override(IVestingNFT) returns (uint256 payout) {
+    function vestedPayout(uint256 tokenId) public view override(IERC5725) returns (uint256 payout) {
         return vestedPayoutAtTime(tokenId, block.timestamp);
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)
         public
         view
         virtual
-        override(IVestingNFT)
+        override(IERC5725)
         returns (uint256 payout);
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function vestingPayout(uint256 tokenId)
         public
         view
-        override(IVestingNFT)
+        override(IERC5725)
         validToken(tokenId)
         returns (uint256 payout)
     {
@@ -69,12 +69,12 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function claimablePayout(uint256 tokenId)
         public
         view
-        override(IVestingNFT)
+        override(IERC5725)
         validToken(tokenId)
         returns (uint256 payout)
     {
@@ -82,12 +82,12 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function vestingPeriod(uint256 tokenId)
         public
         view
-        override(IVestingNFT)
+        override(IERC5725)
         validToken(tokenId)
         returns (uint256 vestingStart, uint256 vestingEnd)
     {
@@ -95,12 +95,12 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function payoutToken(uint256 tokenId)
         public
         view
-        override(IVestingNFT)
+        override(IERC5725)
         validToken(tokenId)
         returns (address token)
     {
@@ -109,7 +109,7 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
 
     /**
      * @dev See {IERC165-supportsInterface}.
-     * IVestingNFT interfaceId = 0xf8600f8b
+     * IERC5725 interfaceId = 0xf8600f8b
      */
     function supportsInterface(bytes4 interfaceId)
         public
@@ -118,7 +118,7 @@ abstract contract BaseVestingNFT is IVestingNFT, ERC721 {
         override(ERC721, IERC165)
         returns (bool supported)
     {
-        return interfaceId == type(IVestingNFT).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC5725).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /**

--- a/assets/eip-5725/contracts/IERC5725.sol
+++ b/assets/eip-5725/contracts/IERC5725.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
  * @dev Because this standard relies on timestamps for the vesting schedule, it's important to keep track of the
  *  tokens claimed per Vesting NFT so that a user cannot withdraw more tokens than alloted for a specific Vesting NFT.
  */
-interface IVestingNFT is IERC721 {
+interface IERC5725 is IERC721 {
     event PayoutClaimed(uint256 indexed tokenId, address indexed recipient, uint256 _claimAmount);
 
     /**

--- a/assets/eip-5725/contracts/reference/LinearVestingNFT.sol
+++ b/assets/eip-5725/contracts/reference/LinearVestingNFT.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.17;
 
-import "../BaseVestingNFT.sol";
+import "../ERC5725.sol";
 
-contract LinearVestingNFT is BaseVestingNFT {
+contract LinearVestingNFT is ERC5725 {
     using SafeERC20 for IERC20;
 
     struct VestDetails {
@@ -19,7 +19,7 @@ contract LinearVestingNFT is BaseVestingNFT {
     uint256 private _tokenIdTracker;
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
@@ -61,12 +61,12 @@ contract LinearVestingNFT is BaseVestingNFT {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)
         public
         view
-        override(BaseVestingNFT)
+        override(ERC5725)
         validToken(tokenId)
         returns (uint256 payout)
     {
@@ -80,28 +80,28 @@ contract LinearVestingNFT is BaseVestingNFT {
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _payoutToken(uint256 tokenId) internal view override returns (address) {
         return address(vestDetails[tokenId].payoutToken);
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _payout(uint256 tokenId) internal view override returns (uint256) {
         return vestDetails[tokenId].payout;
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _startTime(uint256 tokenId) internal view override returns (uint256) {
         return vestDetails[tokenId].startTime;
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _endTime(uint256 tokenId) internal view override returns (uint256) {
         return vestDetails[tokenId].endTime;

--- a/assets/eip-5725/contracts/reference/VestingNFT.sol
+++ b/assets/eip-5725/contracts/reference/VestingNFT.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.17;
 
-import "../BaseVestingNFT.sol";
+import "../ERC5725.sol";
 
-contract VestingNFT is BaseVestingNFT {
+contract VestingNFT is ERC5725 {
     using SafeERC20 for IERC20;
 
     struct VestDetails {
@@ -54,12 +54,12 @@ contract VestingNFT is BaseVestingNFT {
     }
 
     /**
-     * @dev See {IVestingNFT}.
+     * @dev See {IERC5725}.
      */
     function vestedPayoutAtTime(uint256 tokenId, uint256 timestamp)
         public
         view
-        override(BaseVestingNFT)
+        override(ERC5725)
         validToken(tokenId)
         returns (uint256 payout)
     {
@@ -70,28 +70,28 @@ contract VestingNFT is BaseVestingNFT {
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _payoutToken(uint256 tokenId) internal view override returns (address) {
         return address(vestDetails[tokenId].payoutToken);
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _payout(uint256 tokenId) internal view override returns (uint256) {
         return vestDetails[tokenId].payout;
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _startTime(uint256 tokenId) internal view override returns (uint256) {
         return vestDetails[tokenId].startTime;
     }
 
     /**
-     * @dev See {BaseVestingNFT}.
+     * @dev See {ERC5725}.
      */
     function _endTime(uint256 tokenId) internal view override returns (uint256) {
         return vestDetails[tokenId].endTime;

--- a/assets/eip-5725/test/VestingNFT.test.ts
+++ b/assets/eip-5725/test/VestingNFT.test.ts
@@ -37,13 +37,13 @@ describe('VestingNFT', function () {
     unlockTime = await createVestingNft(vestingNFT, receiverAccount, mockToken)
   })
 
-  it('Supports ERC721 and IVestingNFT interfaces', async function () {
+  it('Supports ERC721 and IERC5725 interfaces', async function () {
     expect(await vestingNFT.supportsInterface('0x80ac58cd')).to.equal(true)
 
     /**
      * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified
      * // Solidity export interface id:
-     * bytes4 public constant IID_ITEST = type(IVestingNFT).interfaceId;
+     * bytes4 public constant IID_ITEST = type(IERC5725).interfaceId;
      * // Pull out the interfaceId in tests
      * const interfaceId = await vestingNFT.IID_ITEST();
      */


### PR DESCRIPTION
Rebranding `IVestingNFT` to be in accordance with the `ERCXXXX` naming convention used elsewhere in this repo. 